### PR TITLE
Ajout des différentes routes pour le navigator

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,7 +15,7 @@ class MyApp extends StatelessWidget {
         primarySwatch: Colors.blue,
         visualDensity: VisualDensity.adaptivePlatformDensity,
       ),
-      home: HomePage(title: 'Restaurant Delivery Home Page'),
+      routes: {'/': (context) => HomePage(), '/dish': (context) => HomePage(), '/profile': (context) => HomePage(), '/basket': (context) => HomePage()},
     );
   }
 }

--- a/lib/page/home-page.dart
+++ b/lib/page/home-page.dart
@@ -33,9 +33,11 @@ class _HomePageState extends State<HomePage> {
     Icons.shopping_basket_outlined,
   ];
 
-  void shoppingBasketRoad() {
-    print("Shopping basket icon clicked !");
-  }
+  final routeList = <String>[
+    "/",
+    "/profile",
+    "/basket",
+  ];
 
   void searchButtonRoad() {}
 
@@ -118,7 +120,9 @@ class _HomePageState extends State<HomePage> {
         notchSmoothness: NotchSmoothness.verySmoothEdge,
         leftCornerRadius: 0,
         rightCornerRadius: 0,
-        onTap: (index) => setState(() => _bottomNavIndex = index),
+        onTap: (index) => 
+          Navigator.pushReplacementNamed(context, routeList[index])
+        ,
       ),
     );
   }


### PR DESCRIPTION
Du coups on a toutes les routes pour pouvoir naviguer (/dish, /basket, /profile, /)

J'ai remarqué que la bottomTabNavigator est directement intégré dans la vue Home (au lieu d'être séparé), du coups je suppose que quand on fera les vues profile et basket on devrait copier cette bottomTabNavigator et mettre l'index sur la bonne icone. Je me demandais si on devait séparé la vue Home et cette bottomTabNavigator ou si on les laisser ensemble (et donc refaire cette bottomTab dans les deux autres vues ), pingez moi si je suis pas clair 